### PR TITLE
audit: sanitize non-finite sidecar features

### DIFF
--- a/umap-service/audio_source.py
+++ b/umap-service/audio_source.py
@@ -11,6 +11,7 @@ and extracted features are cached indefinitely.
 
 import json
 import logging
+import math
 import os
 import re
 import sqlite3
@@ -24,6 +25,26 @@ logger = logging.getLogger(__name__)
 
 DB_PATH = os.environ.get("FEATURES_DB_PATH", os.path.join(os.path.dirname(__file__), "data", "features.db"))
 AUDIO_DIR = os.environ.get("AUDIO_DIR", os.path.join(os.path.dirname(__file__), "data", "audio"))
+
+
+def _sanitize_float_vector(values: list[float]) -> list[float]:
+    """Normalize cached vectors so legacy NaN/Infinity rows cannot poison JSON."""
+    clean: list[float] = []
+    for value in values:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            number = 0.0
+        clean.append(number if math.isfinite(number) else 0.0)
+    return clean
+
+
+def _load_float_vector(raw_json: str) -> list[float]:
+    return _sanitize_float_vector(json.loads(raw_json))
+
+
+def _dump_strict_json(value: object) -> str:
+    return json.dumps(value, allow_nan=False)
 
 
 @dataclass
@@ -137,14 +158,14 @@ def get_cached_features(spotify_id: str) -> list[float] | None:
     conn.close()
     if row is None:
         return None
-    return json.loads(row[0])
+    return _load_float_vector(row[0])
 
 
 def cache_features(spotify_id: str, features: list[float]) -> None:
     conn = _get_db()
     conn.execute(
         "INSERT OR REPLACE INTO audio_features (spotify_id, features) VALUES (?, ?)",
-        (spotify_id, json.dumps(features)),
+        (spotify_id, _dump_strict_json(_sanitize_float_vector(features))),
     )
     conn.commit()
     conn.close()
@@ -154,7 +175,7 @@ def get_all_cached_features() -> dict[str, list[float]]:
     conn = _get_db()
     rows = conn.execute("SELECT spotify_id, features FROM audio_features").fetchall()
     conn.close()
-    return {row[0]: json.loads(row[1]) for row in rows}
+    return {row[0]: _load_float_vector(row[1]) for row in rows}
 
 
 # ─── TF Embedding Cache ─────────────────────────────────────────────────────
@@ -169,14 +190,14 @@ def get_cached_embedding(spotify_id: str) -> list[float] | None:
     conn.close()
     if row is None:
         return None
-    return json.loads(row[0])
+    return _load_float_vector(row[0])
 
 
 def cache_embedding(spotify_id: str, embedding: list[float]) -> None:
     conn = _get_db()
     conn.execute(
         "INSERT OR REPLACE INTO tf_embeddings (spotify_id, embedding) VALUES (?, ?)",
-        (spotify_id, json.dumps(embedding)),
+        (spotify_id, _dump_strict_json(_sanitize_float_vector(embedding))),
     )
     conn.commit()
     conn.close()
@@ -186,7 +207,7 @@ def get_all_cached_embeddings() -> dict[str, list[float]]:
     conn = _get_db()
     rows = conn.execute("SELECT spotify_id, embedding FROM tf_embeddings").fetchall()
     conn.close()
-    return {row[0]: json.loads(row[1]) for row in rows}
+    return {row[0]: _load_float_vector(row[1]) for row in rows}
 
 
 # ─── YouTube Music Search ────────────────────────────────────────────────────

--- a/umap-service/feature_extract.py
+++ b/umap-service/feature_extract.py
@@ -181,4 +181,7 @@ def _compute_features(audio: np.ndarray) -> list[float]:
     ])
 
     assert len(features) == FEATURE_DIM
+    # Legacy cache rows may contain non-finite values, but new extraction output
+    # should always be browser-JSON-safe before it is cached or streamed.
+    features = np.nan_to_num(features, nan=0.0, posinf=0.0, neginf=0.0)
     return features.tolist()

--- a/umap-service/main.py
+++ b/umap-service/main.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import math
 import os
 import subprocess
 import sys
@@ -37,6 +38,25 @@ DEBUG_MODE = os.environ.get("DEBUG", "").lower() in ("1", "true", "yes")
 
 # Unauthenticated YTMusic client — sufficient for search
 _yt: YTMusic | None = None
+
+
+def _sanitize_float_vector(values: list[float]) -> list[float]:
+    clean: list[float] = []
+    for value in values:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            number = 0.0
+        clean.append(number if math.isfinite(number) else 0.0)
+    return clean
+
+
+def _sanitize_float_map(values: dict[str, list[float]]) -> dict[str, list[float]]:
+    return {key: _sanitize_float_vector(vector) for key, vector in values.items()}
+
+
+def _dump_strict_json(value: object) -> str:
+    return json.dumps(value, allow_nan=False)
 
 
 def get_yt() -> YTMusic:
@@ -94,6 +114,7 @@ def _compute_umap(
         return UMAPResponse(coordinates={})
 
     matrix = np.array([features[tid] for tid in valid_ids], dtype=np.float64)
+    matrix = np.nan_to_num(matrix, nan=0.0, posinf=0.0, neginf=0.0)
 
     # Check cache (key includes UMAP parameters so different settings get separate entries)
     key_input = matrix.tobytes() + f"|{n_neighbors}|{min_dist}".encode()
@@ -114,6 +135,7 @@ def _compute_umap(
         raw_ids = [tid for tid in valid_ids if tid in raw_features]
         if len(raw_ids) > 10:
             raw_matrix = np.array([raw_features[tid] for tid in raw_ids], dtype=np.float64)
+            raw_matrix = np.nan_to_num(raw_matrix, nan=0.0, posinf=0.0, neginf=0.0)
             raw_coords_x = np.array([coordinates[tid][0] for tid in raw_ids])
             raw_coords_y = np.array([coordinates[tid][1] for tid in raw_ids])
             x_axis = _best_axis_correlation(raw_matrix, raw_coords_x, AXIS_FEATURE_NAMES)
@@ -129,7 +151,7 @@ def _run_numba_subprocess(script: str, input_data: dict, timeout: int, label: st
     """
     result = subprocess.run(
         [sys.executable, "-c", script],
-        input=json.dumps(input_data),
+        input=_dump_strict_json(input_data),
         capture_output=True,
         text=True,
         timeout=timeout,
@@ -159,7 +181,8 @@ if normalized.shape[1] > 50:
 
 eff_neighbors = max(2, min(n_neighbors, matrix.shape[0] - 1))
 coords = UMAP(n_components=2, n_neighbors=eff_neighbors, min_dist=min_dist, random_state=42, n_jobs=1).fit_transform(normalized)
-print(json.dumps(coords.tolist()))
+coords = np.nan_to_num(coords, nan=0.0, posinf=0.0, neginf=0.0)
+print(json.dumps(coords.tolist(), allow_nan=False))
 """
 
 _HDBSCAN_SCRIPT = """
@@ -169,7 +192,7 @@ from hdbscan import HDBSCAN
 data = json.loads(sys.stdin.read())
 matrix = np.array(data["matrix"], dtype=np.float64)
 labels = HDBSCAN(min_cluster_size=data["min_cluster_size"], min_samples=3).fit_predict(matrix)
-print(json.dumps(labels.tolist()))
+print(json.dumps(labels.tolist(), allow_nan=False))
 """
 
 
@@ -249,7 +272,7 @@ def _get_umap_cache(cache_key: str) -> dict[str, list[float]] | None:
     conn.close()
     if row is None:
         return None
-    return json.loads(row[0])
+    return _sanitize_float_map(json.loads(row[0]))
 
 
 def _cache_umap(cache_key: str, coordinates: dict[str, list[float]]) -> None:
@@ -257,7 +280,7 @@ def _cache_umap(cache_key: str, coordinates: dict[str, list[float]]) -> None:
     conn = _get_db()
     conn.execute(
         "INSERT OR REPLACE INTO umap_cache (cache_key, coordinates) VALUES (?, ?)",
-        (cache_key, json.dumps(coordinates)),
+        (cache_key, _dump_strict_json(_sanitize_float_map(coordinates))),
     )
     conn.commit()
     conn.close()
@@ -309,6 +332,7 @@ def _compute_clusters(
         return ClusterResponse(labels={}, insights=[])
 
     matrix = np.array([coordinates[tid] for tid in track_ids], dtype=np.float64)
+    matrix = np.nan_to_num(matrix, nan=0.0, posinf=0.0, neginf=0.0)
 
     labels_list = _run_hdbscan_subprocess(matrix, min_cluster_size)
 
@@ -479,7 +503,7 @@ async def run_feature_extraction(body: FeaturesRequest, request: Request):
 
     async def generate():
         def send(obj: dict):
-            return f"data: {json.dumps(obj)}\n\n"
+            return f"data: {_dump_strict_json(obj)}\n\n"
 
         yt = get_yt()
         total = len(body.tracks)

--- a/umap-service/tf_extract.py
+++ b/umap-service/tf_extract.py
@@ -86,6 +86,7 @@ def extract_embedding(file_path: str) -> list[float] | None:
 
         # Average across patches for a single track-level embedding
         embedding = np.mean(embeddings, axis=0)
+        embedding = np.nan_to_num(embedding, nan=0.0, posinf=0.0, neginf=0.0)
         return embedding.tolist()
     except Exception as e:
         logger.warning("TF embedding extraction failed for %s: %s", file_path, e)


### PR DESCRIPTION
## Audit Fixes (Batch 1)

<!-- audit-revision: 0 -->

Closes #1: NaN/Infinity in Essentia features break JSON parsing on the client

## Root Cause Analysis
Root cause: Raw and TensorFlow feature extraction can produce non-finite NumPy values, and the sidecar currently caches and streams them with Python's permissive JSON encoder.

Fix: Sanitize extracted vectors in `umap-service/feature_extract.py` and `umap-service/tf_extract.py`, then harden cache and SSE serialization in `umap-service/audio_source.py` and `umap-service/main.py` with strict JSON encoding and cache-read normalization.

Risk: Strict JSON encoding can expose existing poisoned cache rows, so cache reads should coerce legacy non-finite data before returning it to API responses.

## Changes
- Replaced NaN, Infinity, and -Infinity with 0.0 at raw-feature and TensorFlow embedding extraction boundaries.
- Normalized legacy cached feature and embedding vectors when reading from SQLite.
- Wrote cache, UMAP cache, subprocess input/output, and SSE payloads with strict JSON encoding.
- Sanitized UMAP and HDBSCAN matrices before subprocess calls so poisoned inputs cannot leak back into browser-facing JSON.

## Test plan
- `python -m py_compile umap-service/feature_extract.py umap-service/tf_extract.py umap-service/audio_source.py umap-service/main.py`
- `git diff --check`
- Smoke test with a temporary `features.db`: cache vectors containing `NaN`, `Infinity`, `-Infinity`, and a manually inserted legacy poisoned row, then verify reads return finite values only.