### PR TITLE
audit: harden genre view parsing

### DIFF
--- a/next-app/src/app/api/genres/route.ts
+++ b/next-app/src/app/api/genres/route.ts
@@ -2,8 +2,20 @@ import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
 import { scrapeGenreCoordinates } from "@/lib/genre-scraper";
 import { getCachedLibrary, getCachedGenres, cacheGenres } from "@/lib/db";
+import type { SpotifyArtist } from "@/lib/spotify";
 
 export const dynamic = "force-dynamic";
+
+function isSpotifyArtist(value: unknown): value is SpotifyArtist {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "id" in value &&
+    typeof value.id === "string" &&
+    "genres" in value &&
+    Array.isArray(value.genres)
+  );
+}
 
 export async function GET() {
   const session = await getSession();
@@ -35,6 +47,7 @@ export async function GET() {
     // Build artist ID → genres lookup
     const artistGenres = new Map<string, string[]>();
     for (const artist of library.artists) {
+      if (!isSpotifyArtist(artist)) continue;
       if (artist.genres.length > 0) {
         artistGenres.set(
           artist.id,

--- a/next-app/src/lib/genre-scraper.ts
+++ b/next-app/src/lib/genre-scraper.ts
@@ -20,6 +20,10 @@ export interface GenreCoord {
 const EVERYNOISE_URL = "https://everynoise.com";
 const CANVAS_WIDTH = 1610;
 
+function decodeHtmlEntities(value: string): string {
+  return cheerio.load(value).root().text();
+}
+
 export async function scrapeGenreCoordinates(): Promise<GenreCoord[]> {
   const response = await fetch(EVERYNOISE_URL, {
     signal: AbortSignal.timeout(30_000),
@@ -53,12 +57,14 @@ export function parseGenreCoordinates(html: string): GenreCoord[] {
     if (!topMatch || !leftMatch) return;
 
     // Extract genre name from onclick: playx("...", "genre name", this)
-    const nameMatch = onclick.match(/playx\([^,]+,\s*"([^"]+)"/);
-    // Some genres use &quot; entities
-    const nameMatch2 = onclick.match(
-      /playx\([^,]+,\s*&quot;([^&]+)&quot;/,
-    );
-    const name = nameMatch?.[1] ?? nameMatch2?.[1];
+    const decodedOnclick = decodeHtmlEntities(onclick);
+    const doubleQuotedName = decodedOnclick.match(
+      /playx\([^,]+,\s*"([^"]+)"/,
+    )?.[1];
+    const singleQuotedName = decodedOnclick.match(
+      /playx\([^,]+,\s*'([^']+)'/,
+    )?.[1];
+    const name = doubleQuotedName ?? singleQuotedName;
     if (!name) return;
 
     const top = parseInt(topMatch[1], 10);

--- a/next-app/src/lib/spotify.ts
+++ b/next-app/src/lib/spotify.ts
@@ -308,12 +308,15 @@ export async function getArtists(
     const batch = artistIds.slice(i, i + batchSize);
     const ids = batch.join(",");
 
-    const data = await spotifyFetch<{ artists: SpotifyArtist[] }>(
+    const data = await spotifyFetch<{ artists: (SpotifyArtist | null)[] }>(
       `${SPOTIFY_API_BASE}/artists?ids=${ids}`,
       accessToken,
     );
 
-    allArtists.push(...data.artists);
+    const validArtists = data.artists.filter(
+      (artist): artist is SpotifyArtist => artist !== null,
+    );
+    allArtists.push(...validArtists);
 
     if (onProgress) {
       onProgress(


### PR DESCRIPTION
## Audit Fixes (Batch 2)

<!-- audit-revision: 0 -->

Closes #2: Genre scraper ampersand parsing
Closes #3: Nullable Spotify artists in Genre view

## Root Cause Analysis
Issue #2 root cause: The Every Noise fallback parser treats `&` as a terminator while matching `&quot;...&quot;`, so HTML-escaped names such as `rhythm &amp; blues` are truncated before downstream lowercase lookup.

Issue #2 fix: Decode the raw `onclick` attribute with Cheerio before extracting the quoted genre argument in `next-app/src/lib/genre-scraper.ts`, so both literal quotes and entity-escaped quotes/entities flow through one parser.

Issue #2 risk: Broadening the parser could accidentally capture the wrong quoted argument if the `playx(...)` shape changes, so the match still anchors on the second argument after the first comma.

Issue #3 root cause: Spotify can return null entries from `/v1/artists?ids=...`, but `getArtists` typed the response as non-null and the cached Genre route assumed every cached artist has a `genres` array.

Issue #3 fix: Filter null artists in `next-app/src/lib/spotify.ts` before returning/cache writes, and defensively skip legacy null/malformed cached artists in `next-app/src/app/api/genres/route.ts`.

Issue #3 risk: Filtering nulls reduces the artist count for deleted artists, but that matches the usable data surface and prevents one dead artist from blocking Genre view coordinates.

## Changes
- Decode Every Noise `onclick` entities before parsing the genre name, preserving names like `rhythm & blues`.
- Support both double-quoted and single-quoted `playx` genre arguments while keeping the parser anchored to the second argument.
- Type Spotify `/artists` responses as `(SpotifyArtist | null)[]` and filter nulls before returning artists.
- Add a Genre route type guard so existing cached null or malformed artist rows are skipped instead of crashing the request.

## Test plan
- `npx tsc --noEmit`
- `npx eslint src/lib/genre-scraper.ts src/lib/spotify.ts src/app/api/genres/route.ts`
- `git diff --check`
- Parser smoke test: decoded `playx(foo, &quot;rhythm &amp; blues&quot;, this)` to `rhythm & blues`.

## Notes
- `npm run lint` still fails on pre-existing, unrelated files outside this batch: `src/components/PreviewPlayer.tsx`, `src/components/ThemeToggle.tsx`, and warnings in `src/app/dashboard/DashboardClient.tsx`. The touched files pass ESLint directly.