### PR TITLE
audit: require POST for logout

### DIFF
--- a/next-app/src/app/api/auth/logout/route.ts
+++ b/next-app/src/app/api/auth/logout/route.ts
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth";
 
-export async function GET() {
+export async function POST() {
   const session = await getSession();
   session.destroy();
   redirect("/");

--- a/next-app/src/app/dashboard/page.tsx
+++ b/next-app/src/app/dashboard/page.tsx
@@ -25,16 +25,18 @@ export default async function Dashboard() {
           <span className="text-sm" style={{ color: "var(--ctp-subtext0)" }}>
             {session.displayName}
           </span>
-          <a
-            href="/api/auth/logout"
-            className="rounded-full px-3 py-1 text-sm transition-colors"
-            style={{
-              border: "1px solid var(--ctp-surface1)",
-              color: "var(--ctp-subtext1)",
-            }}
-          >
-            Log out
-          </a>
+          <form action="/api/auth/logout" method="post">
+            <button
+              type="submit"
+              className="rounded-full px-3 py-1 text-sm transition-colors"
+              style={{
+                border: "1px solid var(--ctp-surface1)",
+                color: "var(--ctp-subtext1)",
+              }}
+            >
+              Log out
+            </button>
+          </form>
         </div>
       </header>
       <main className="flex-1 overflow-hidden">


### PR DESCRIPTION
## Audit Fixes (Batch 3)

<!-- audit-revision: 0 -->

Closes #4: Logout is a GET — CSRF can log users out

## Root Cause Analysis
Root cause: `/api/auth/logout` destroys the session from a GET handler, so cross-site navigations or embedded resources can trigger a state-changing request with the user's lax session cookie.

Fix: Replace the GET handler with a POST handler in `next-app/src/app/api/auth/logout/route.ts` and update the dashboard logout control in `next-app/src/app/dashboard/page.tsx` to submit a POST form.

Risk: Logout navigation could regress if the POST response does not redirect cleanly after destroying the iron-session cookie, so the handler uses Next.js `redirect("/")` after `session.destroy()` and avoids wrapping it in try/catch.

## Changes
- `/api/auth/logout` now only exports `POST`, so GET requests do not destroy the session.
- The dashboard header logout control is now a POST form submit button that keeps the page as a server component.
- The handler destroys the iron-session cookie and redirects to `/` on the same Next.js response path.

## Test plan
- `npx tsc --noEmit`
- `npx eslint src/app/api/auth/logout/route.ts src/app/dashboard/page.tsx`
- `git diff --check`
- Route scan confirmed logout route exports `POST()` and the dashboard submits `method="post"` to `/api/auth/logout`.