### PR TITLE
audit: bound rate-limit waits and youtube id queries

### DIFF
--- a/next-app/src/lib/spotify.ts
+++ b/next-app/src/lib/spotify.ts
@@ -7,6 +7,7 @@ const SPOTIFY_API_BASE = "https://api.spotify.com/v1";
 const CLIENT_ID = process.env.SPOTIFY_CLIENT_ID!;
 const CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET!;
 const REDIRECT_URI = process.env.SPOTIFY_REDIRECT_URI!;
+const MAX_RETRY_AFTER_SECONDS = 60;
 
 // Rate limiter: Spotify allows ~30 req/sec, we use concurrency 10 to be safe
 const queue = new PQueue({ concurrency: 10, interval: 1000, intervalCap: 25 });
@@ -164,7 +165,13 @@ async function spotifyFetch<T>(url: string, accessToken: string): Promise<T> {
 
     if (response.status === 429) {
       const retryAfter = parseInt(response.headers.get("Retry-After") || "1", 10);
-      await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
+      const waitSeconds = Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter : 1;
+      if (waitSeconds > MAX_RETRY_AFTER_SECONDS) {
+        throw new Error(
+          `Spotify rate limit asks to retry after ${waitSeconds}s; refusing to block the queue longer than ${MAX_RETRY_AFTER_SECONDS}s`,
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, waitSeconds * 1000));
       // Retry once after waiting
       const retry = await fetch(url, {
         headers: { Authorization: `Bearer ${accessToken}` },

--- a/umap-service/main.py
+++ b/umap-service/main.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 app = FastAPI(title="UMAP Service", version="0.2.0")
 
 DEBUG_MODE = os.environ.get("DEBUG", "").lower() in ("1", "true", "yes")
+SQLITE_IN_CHUNK_SIZE = 500
 
 # Unauthenticated YTMusic client — sufficient for search
 _yt: YTMusic | None = None
@@ -451,16 +452,25 @@ async def get_youtube_ids(body: CachedFeaturesRequest):
     """Return cached (video_id, duration_s) for each requested track ID."""
     def query():
         from audio_source import _get_db  # lazy — keeps module import surface small
+        requested = list(dict.fromkeys(body.track_ids))
+        if not requested:
+            return {}
+
         conn = _get_db()
-        rows = conn.execute(
-            "SELECT spotify_id, video_id, duration_s FROM youtube_matches",
-        ).fetchall()
-        requested = set(body.track_ids)
-        return {
-            row[0]: [row[1], row[2]]
-            for row in rows
-            if row[0] in requested
-        }
+        ids: dict[str, list] = {}
+        try:
+            for start in range(0, len(requested), SQLITE_IN_CHUNK_SIZE):
+                batch = requested[start:start + SQLITE_IN_CHUNK_SIZE]
+                placeholders = ",".join("?" for _ in batch)
+                rows = conn.execute(
+                    f"SELECT spotify_id, video_id, duration_s FROM youtube_matches WHERE spotify_id IN ({placeholders})",
+                    batch,
+                ).fetchall()
+                for row in rows:
+                    ids[row[0]] = [row[1], row[2]]
+        finally:
+            conn.close()
+        return ids
     ids = await asyncio.to_thread(query)
     return {"ids": ids}
 


### PR DESCRIPTION
## Audit Fixes (Batch 5)

<!-- audit-revision: 0 -->

Closes #6: Spotify Retry-After is honored unbounded — one 429 can stall the queue for an hour
Closes #7: /api/youtube-ids reads all youtube_matches rows then filters in Python

## Root Cause Analysis
Issue #6 root cause: `spotifyFetch` sleeps inside a `p-queue` worker for the full `Retry-After` header, so a large Spotify rate-limit value can occupy queue slots for minutes or hours.

Issue #6 fix: Parse `Retry-After` defensively in `next-app/src/lib/spotify.ts`, wait only up to a bounded 60-second ceiling for normal short retries, and fail fast when Spotify asks for a longer wait.

Issue #6 risk: Requests that previously waited a very long time will now surface an error sooner, but that is preferable to freezing the library loader with no progress.

Issue #7 root cause: `get_youtube_ids` fetches every `youtube_matches` row from SQLite, then filters in Python even though the caller provides a bounded list of requested Spotify IDs.

Issue #7 fix: Query `youtube_matches` with parameterized `IN` clauses in `umap-service/main.py`, chunking requested IDs at 500 per query and closing the connection after the query.

Issue #7 risk: Empty requested ID lists and duplicate IDs need stable behavior, so the query returns `{}` for empty input and deduplicates requested IDs before querying.

## Changes
- Added `MAX_RETRY_AFTER_SECONDS = 60` and fail-fast behavior for excessive Spotify `Retry-After` values.
- Kept short Spotify 429 waits working with one retry after the bounded wait.
- Replaced `/youtube-ids` full-table scan with chunked `WHERE spotify_id IN (...)` queries.
- Added an empty-request fast path and `try/finally` connection close around the SQLite query.

## Test plan
- `npx tsc --noEmit`
- `npx eslint src/lib/spotify.ts`
- `python -m py_compile umap-service/main.py`
- `git diff --check`
- SQLite smoke test with 1,200 cached matches and requested duplicate/missing IDs; query returned only the requested cached matches.

## Notes
- `npm run lint` still fails on pre-existing, unrelated files outside this batch: `src/components/PreviewPlayer.tsx`, `src/components/ThemeToggle.tsx`, and warnings in `src/app/dashboard/DashboardClient.tsx`. The touched TypeScript file passes ESLint directly.