### PR TITLE
audit: harden Docker runtime health

### DIFF
--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -5,11 +5,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-COPY umap-service/environment.yml .
+COPY --chown=mambauser:mambauser umap-service/environment.yml .
 RUN micromamba env create -y -f environment.yml && \
     micromamba clean --all --yes
 
-COPY umap-service/ .
+COPY --chown=mambauser:mambauser umap-service/ .
+RUN mkdir -p /app/data/audio /app/models && \
+    chown -R mambauser:mambauser /app
 
+USER mambauser
 EXPOSE 8000
 CMD ["micromamba", "run", "-n", "spotify-project", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,12 @@ services:
     depends_on:
       umap:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "-T", "3", "http://localhost:3000/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
 
   umap:
     build:


### PR DESCRIPTION
## Audit Fixes (Batch 1)

<!-- audit-revision: 0 -->

Closes #13: Dockerfile.python runs uvicorn as root
Closes #16: docker-compose web service has no healthcheck — orchestrator can't detect hangs

## Root Cause Analysis
Issue #13 root cause: `Dockerfile.python` switches to `USER root` to install `curl` and never returns to the base image's non-root `mambauser`, so uvicorn, yt-dlp, TensorFlow/Essentia, and subprocess workloads all run with container root privileges.

Issue #13 fix: Keep package installation as root, copy application files with `mambauser` ownership, make the writable sidecar data directories available to that user, and switch to `USER mambauser` before the `CMD`.

Issue #13 risk: Dropping privileges can break writes to `umap-service/data/` or model access if ownership is wrong, so the image explicitly owns `/app` content and creates writable runtime directories before changing users.

Issue #16 root cause: `docker-compose.yml` gates `web` on the healthy `umap` sidecar but never defines a liveness probe for the user-facing Next.js container, so Compose cannot report or gate on web health.

Issue #16 fix: Add a `web` healthcheck using Alpine's BusyBox `wget --spider` against `http://localhost:3000/`, with a start period long enough for Next.js startup.

Issue #16 risk: A too-aggressive healthcheck can mark web unhealthy during normal startup, so the probe uses a gentler 30s interval and 20s start period.

## Changes
- `Dockerfile.python` now copies sidecar files as `mambauser`, prepares writable `/app/data/audio` and `/app/models`, and runs uvicorn as `mambauser`.
- `docker-compose.yml` now defines a `web` healthcheck for `/` using BusyBox `wget`.

## Test plan
- `ruby -e "require 'yaml'; ..."` parsed `docker-compose.yml` and confirmed both `web` and `umap` healthchecks exist.
- `awk '/^USER / { print NR ":" $0 }' Dockerfile.python` confirmed the Dockerfile switches from `USER root` to `USER mambauser` before `CMD`.
- `git diff --check`

## Not run
- `docker compose config` / `docker compose up`: Docker is not installed in this environment (`zsh:1: command not found: docker`).