### PR TITLE
audit: filter null artists in demo export

### DIFF
--- a/next-app/scripts/export-demo.mjs
+++ b/next-app/scripts/export-demo.mjs
@@ -37,7 +37,9 @@ if (!libRow) throw new Error("No library_cache row — run a Spotify sync first"
 const rawTracks = JSON.parse(libRow.tracks);
 const rawPlaylists = JSON.parse(libRow.playlists);
 const playlistTracks = JSON.parse(libRow.playlist_tracks);
-const rawArtists = JSON.parse(libRow.artists);
+const rawArtists = JSON.parse(libRow.artists).filter(
+  (a) => a && typeof a === "object" && typeof a.id === "string",
+);
 
 // Pick the smallest album image (usually 64px) to keep bundle tiny
 function smallestImage(images) {


### PR DESCRIPTION
## Audit Fixes (Batch 2)

<!-- audit-revision: 0 -->

Closes #14: export-demo.mjs crashes on null cached artists

## Root Cause Analysis
Root cause: `next-app/scripts/export-demo.mjs` parses `library_cache.artists` and then dereferences each entry as an object, but legacy cache rows can contain `null` entries from before Spotify artist responses were filtered.

Fix: Filter parsed artist entries immediately after reading `libRow.artists`, keeping only object entries with a string `id` so the existing export mapping and genre lookup loops cannot dereference `null`.

Risk: Filtering malformed artists reduces the exported `artistCount`, but that accurately reflects the usable cached artist data and avoids hiding missing names/genres that the script already defaults downstream.

## Changes
- Added a narrow filter after parsing `libRow.artists` to drop null or malformed entries without changing the rest of the export logic.

## Test plan
- `node --check scripts/export-demo.mjs`
- `npx eslint scripts/export-demo.mjs`
- `git diff --check`
- Node smoke test for `[null, { id: "a1", ... }, { name: "bad" }]` confirmed only the valid artist entry remains.